### PR TITLE
Fix daemon crashing when ELSI request fails

### DIFF
--- a/daemon/src/service/service.py
+++ b/daemon/src/service/service.py
@@ -59,7 +59,7 @@ class Service:
             logger.info("Requesting all tasks through external API...")
             all_tasks = self._http_client.get_all_tasks()
         except Exception as e:
-            logger.err(f"Failed to fetch tasks: {e}")
+            logger.error(f"Failed to fetch tasks: {e}")
 
             return
 


### PR DESCRIPTION
## Description of Issue

Silly bug. Trying to call `logging.err` instead of `logging.error`, ironically makes the daemon crash when you're catching the underlying exception.

It also goes to show something quite interesting, that requests to ELSI do in fact fail now and then.

## Review
- [ ] Commits are atomic
- [ ] Checks are passing
- [ ] Code is sufficiently tested (sufficiently meaning, sometimes a lot, sometimes no need for tests at all)
