### PR TITLE
feat: exclude observability logs

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -194,6 +194,7 @@ services:
     command: -config.file=/etc/loki/config.yml
     networks:
       - echoservice
+      - echoservice-external
   echoservice-promtail:
     container_name: echoservice-promtail
     image: grafana/promtail:2.9.0
@@ -201,8 +202,11 @@ services:
       - ./monitoring/promtail:/etc/promtail
       - /var/run/docker.sock:/var/run/docker.sock
     command: -config.file=/etc/promtail/config.dev.yml
+    ports:
+      - "9080:9080"
     networks:
       - echoservice
+      - echoservice-external
   echoservice-grafana:
     container_name: echoservice-grafana
     image: grafana/grafana:13.0.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -167,6 +167,7 @@ services:
     command: -config.file=/etc/loki/config.yml
     networks:
       - echoswarm
+      - echoswarm-external
     deploy:
       replicas: 1
   echoswarm-promtail:
@@ -175,8 +176,11 @@ services:
       - ./monitoring/promtail:/etc/promtail
       - /var/run/docker.sock:/var/run/docker.sock
     command: -config.file=/etc/promtail/config.prod.yml
+    ports:
+      - "9080:9080"
     networks:
       - echoswarm
+      - echoswarm-external
     deploy:
       mode: global
   echoswarm-grafana:

--- a/monitoring/promtail/config.dev.yml
+++ b/monitoring/promtail/config.dev.yml
@@ -16,3 +16,6 @@ scrape_configs:
     relabel_configs:
       - source_labels: ['__meta_docker_container_name']
         target_label: container
+      - source_labels: ['__meta_docker_container_name']
+        action: drop
+        regex: '.*(netdata|promtail|loki|grafana).*'

--- a/monitoring/promtail/config.dev.yml
+++ b/monitoring/promtail/config.dev.yml
@@ -16,11 +16,8 @@ scrape_configs:
     relabel_configs:
       - target_label: job
         replacement: docker
-      - source_labels: ['__meta_docker_container_name']
+      - source_labels: ['__meta_docker_container_label_com_docker_compose_service']
         target_label: container
-      - source_labels: ['__meta_docker_container_name']
-        action: drop
-        regex: '.*(netdata|promtail|loki|grafana).*'
       - source_labels: ['container']
         action: drop
-        regex: '^$'
+        regex: '.*(netdata|promtail|loki|grafana).*'

--- a/monitoring/promtail/config.dev.yml
+++ b/monitoring/promtail/config.dev.yml
@@ -14,8 +14,13 @@ scrape_configs:
       - host: unix:///var/run/docker.sock
         refresh_interval: 5s
     relabel_configs:
+      - target_label: job
+        replacement: docker
       - source_labels: ['__meta_docker_container_name']
         target_label: container
       - source_labels: ['__meta_docker_container_name']
         action: drop
         regex: '.*(netdata|promtail|loki|grafana).*'
+      - source_labels: ['container']
+        action: drop
+        regex: '^$'

--- a/monitoring/promtail/config.prod.yml
+++ b/monitoring/promtail/config.prod.yml
@@ -16,3 +16,6 @@ scrape_configs:
     relabel_configs:
       - source_labels: ['__meta_docker_container_name']
         target_label: container
+      - source_labels: ['__meta_docker_container_name']
+        action: drop
+        regex: '.*(netdata|promtail|loki|grafana).*'

--- a/monitoring/promtail/config.prod.yml
+++ b/monitoring/promtail/config.prod.yml
@@ -16,11 +16,8 @@ scrape_configs:
     relabel_configs:
       - target_label: job
         replacement: docker
-      - source_labels: ['__meta_docker_container_name']
+      - source_labels: ['__meta_docker_container_label_com_docker_compose_service']
         target_label: container
-      - source_labels: ['__meta_docker_container_name']
-        action: drop
-        regex: '.*(netdata|promtail|loki|grafana).*'
       - source_labels: ['container']
         action: drop
-        regex: '^$'
+        regex: '.*(netdata|promtail|loki|grafana).*'

--- a/monitoring/promtail/config.prod.yml
+++ b/monitoring/promtail/config.prod.yml
@@ -14,8 +14,13 @@ scrape_configs:
       - host: unix:///var/run/docker.sock
         refresh_interval: 5s
     relabel_configs:
+      - target_label: job
+        replacement: docker
       - source_labels: ['__meta_docker_container_name']
         target_label: container
       - source_labels: ['__meta_docker_container_name']
         action: drop
         regex: '.*(netdata|promtail|loki|grafana).*'
+      - source_labels: ['container']
+        action: drop
+        regex: '^$'


### PR DESCRIPTION
## Description of Issue

Observability logs are very spammy. The problem is that logs are kept for 30 days, so this will probably create too many logs for the log database.

## Description of Solution

<Description of how the problems have been solved>

## Review
- [ ] Commits are atomic
- [ ] Checks are passing
- [ ] Code is sufficiently tested (sufficiently meaning, sometimes a lot, sometimes no need for tests at all)
